### PR TITLE
Make scaling factor for van-der-Waals radii for fragment detection adjustable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- vdW radii scaling parameter can now be adjusted via `mindlessgen.toml` or CLI
+
+### Fixed
+- Unit conversion for (currenly unused) vdW radii from the original Fortran project
+- minor print output issues (no new line breaks...)
+
 ## [0.4.0] - 2024-09-19
 ### Changed
 - Default file name of `.xyz` file contains prefix `mlm_`

--- a/mindlessgen.toml
+++ b/mindlessgen.toml
@@ -29,6 +29,8 @@ init_scaling = 3.0
 increase_scaling_factor = 1.3
 # > Distance threshold for the inital, randomly generated coordinates. Options: <float>
 dist_threshold = 1.2
+# > Scaling factor for the employed van der Waals radii. Options: <float>
+scale_vdw_radii = 1.3333
 # > Atom types and their minimum and maximum occurrences. Format: "<element>:<min_count>-<max_count>"
 # > Elements that are not specified are only added by random selection.
 # > A star sign (*) can be used as a wildcard for integer value.

--- a/src/mindlessgen/cli/cli_parser.py
+++ b/src/mindlessgen/cli/cli_parser.py
@@ -86,6 +86,12 @@ def cli_parser(argv: Sequence[str] | None = None) -> dict:
         required=False,
         help="Do not write the molecules to xyz files.",
     )
+    parser.add_argument(
+        "--scale-vdw-radii",
+        type=float,
+        required=False,
+        help="Scaling factor for van der Waals radii.",
+    )
 
     ### Molecule generation arguments ###
     parser.add_argument(
@@ -266,6 +272,7 @@ def cli_parser(argv: Sequence[str] | None = None) -> dict:
         "dist_threshold": args_dict["dist_threshold"],
         "element_composition": args_dict["element_composition"],
         "forbidden_elements": args_dict["forbidden_elements"],
+        "scale_vdw_radii": args_dict["scale_vdw_radii"],
     }
     # XTB specific arguments
     rev_args_dict["xtb"] = {"xtb_path": args_dict["xtb_path"]}

--- a/src/mindlessgen/molecules/molecule.py
+++ b/src/mindlessgen/molecules/molecule.py
@@ -185,7 +185,7 @@ class Molecule:
         if self._atlist.size:
             if not first_line:
                 returnstr += "\n"
-            returnstr += f"atomic numbers: {self.atlist}"
+            returnstr += f"atomic numbers: {self.atlist}\n"
             returnstr += f"sum formula: {self.sum_formula()}"
             first_line = False
         if self._xyz.size:

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -179,6 +179,7 @@ class GenerateConfig(BaseConfig):
         self._increase_scaling_factor: float = 1.3
         self._element_composition: dict[int, tuple[int | None, int | None]] = {}
         self._forbidden_elements: list[int] | None = None
+        self._scale_vdw_radii: float = 4.0 / 3.0
 
     def get_identifier(self) -> str:
         return "generate"
@@ -363,6 +364,24 @@ class GenerateConfig(BaseConfig):
                 )  # Subtract 1 to convert to 0-based indexing
 
         self._forbidden_elements = sorted(list(forbidden_set))
+
+    @property
+    def scale_vdw_radii(self):
+        """
+        Get the scaling factor for van der Waals radii.
+        """
+        return self._scale_vdw_radii
+
+    @scale_vdw_radii.setter
+    def scale_vdw_radii(self, scale_vdw_radii: float):
+        """
+        Set the scaling factor for van der Waals radii.
+        """
+        if not isinstance(scale_vdw_radii, float):
+            raise TypeError("Scale van der Waals radii should be a float.")
+        if scale_vdw_radii <= 0:
+            raise ValueError("Scale van der Waals radii should be greater than 0.")
+        self._scale_vdw_radii = scale_vdw_radii
 
 
 class RefineConfig(BaseConfig):

--- a/test/test_molecules/test_refinement.py
+++ b/test/test_molecules/test_refinement.py
@@ -106,7 +106,9 @@ def test_detect_fragments_H6O2B2Ne2I1Os1Tl1(
     """
     Test the detection of fragments in the molecule H2O2B2I1Os1.
     """
-    fragmols = detect_fragments(mol_H6O2B2Ne2I1Os1Tl1, verbosity=0)
+    fragmols = detect_fragments(
+        mol=mol_H6O2B2Ne2I1Os1Tl1, vdw_scaling=1.3333, verbosity=0
+    )
     assert len(fragmols) == 7
 
     # check that the first fragment is equal to the molecule H2O2B2I1Os1


### PR DESCRIPTION
- `ConfigClass` entry for the vdW radii scaling parameter (up to now fixed to 4/3). Allows for tighter distance thresholds w.r.t. to fragmentation (safer elimination of single atoms with probably low bond order).
- adjustable via `mindlessgen.toml` and from CLI.
- before, the unused vdW radii were still used in Bohr; they are now converted to Angström via a SotA conversion constant
- scaling is not done within the vdW radii arrays anymore but as a subsequent step when handling the sum of the covalent radii

### Off-topic fixes
- print out format was broken for `sum formula` for `Molecule.__str__`; introduced a new line there to correct it.