### PR TITLE
IP/EA checks with g-xTB as an additional post-processing step

### DIFF
--- a/src/mindlessgen/generator/main.py
+++ b/src/mindlessgen/generator/main.py
@@ -239,14 +239,14 @@ def single_molecule_generator(
         if config.general.verbosity > 1:
             print("Postprocessing successful.")
 
-    if config.general.gp3_development:
-        # additional GP3 engine after refinement and before postprocessing
+    if config.general.gxtb_development:
+        # additional g-xTB engine after refinement and postprocessing for development purposes
         gp3 = GP3(get_gp3_path())
         try:
-            _gp3_dev_check(
+            _gxtb_dev_check(
                 optimized_molecule,
                 gp3,
-                config.general.gp3_scf_cycles,
+                config.general.gxtb_scf_cycles,
                 config.general.verbosity,
             )
         except (RuntimeError, ValueError) as e:
@@ -330,13 +330,13 @@ def setup_engines(
         raise NotImplementedError("Engine not implemented.")
 
 
-def _gp3_dev_check(
+def _gxtb_dev_check(
     mol: Molecule, gp3: GP3, scf_iter_limit: int, verbosity: int = 0
 ) -> None:
     """
     ONLY FOR IN-HOUSE g-xTB DEVELOPMENT PURPOSES: Check the SCF iterations of the cation and anion.
     """
-    # 1) Single point calculation with GP3 for the cation
+    # 1) Single point calculation with g-xTB for the cation
     tmp_mol = mol.copy()
     tmp_mol.charge += 1
     tmp_mol.uhf += 1
@@ -346,7 +346,7 @@ def _gp3_dev_check(
             + "For the g-xTB cationic calculation, we are increasing it by 1. "
             + "(Could be ill-defined.)"
         )
-    gp3_output = gp3.singlepoint(tmp_mol, verbosity=verbosity)
+    gxtb_output = gp3.singlepoint(tmp_mol, verbosity=verbosity)
     # gp3_output looks like this:
     # [...]
     #   13     -155.03101038        0.00000000        0.00000001       16.45392733   8    F
@@ -355,7 +355,7 @@ def _gp3_dev_check(
     # [...]
     # Check for the number of scf iterations
     scf_iterations = 0
-    for line in gp3_output.split("\n"):
+    for line in gxtb_output.split("\n"):
         if "scf iterations" in line:
             scf_iterations = int(line.split()[0])
             break
@@ -364,7 +364,7 @@ def _gp3_dev_check(
     if scf_iterations > scf_iter_limit:
         raise ValueError(f"SCF iterations exceeded limit of {scf_iter_limit}.")
 
-    # 2) Single point calculation with GP3 for the anion
+    # 2) Single point calculation with g-xTB for the anion
     tmp_mol = mol.copy()
     tmp_mol.charge -= 1
     tmp_mol.uhf += 1
@@ -374,10 +374,10 @@ def _gp3_dev_check(
             + "For the g-xTB anionic calculation, we are increasing it by 1. "
             + "(Could be ill-defined.)"
         )
-    gp3_output = gp3.singlepoint(tmp_mol, verbosity=verbosity)
+    gxtb_output = gp3.singlepoint(tmp_mol, verbosity=verbosity)
     # Check for the number of scf iterations
     scf_iterations = 0
-    for line in gp3_output.split("\n"):
+    for line in gxtb_output.split("\n"):
         if "scf iterations" in line:
             scf_iterations = int(line.split()[0])
             break

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -44,8 +44,8 @@ class GeneralConfig(BaseConfig):
 
         ############################################################
         ## g-xTB-specific settings not intended for general use ####
-        self._gp3_development: bool = False
-        self._gp3_scf_cycles: int = 100
+        self._gxtb_development: bool = False
+        self._gxtb_scf_cycles: int = 100
         ### End of g-xTB-specific settings #########################
         ############################################################
 
@@ -175,38 +175,38 @@ class GeneralConfig(BaseConfig):
     ############################################################
     ### g-xTB-specific settings not intended for general use ###
     @property
-    def gp3_development(self):
+    def gxtb_development(self):
         """
-        Get the gp3_development flag.
+        Get the g-xTB development flag.
         """
-        return self._gp3_development
+        return self._gxtb_development
 
-    @gp3_development.setter
-    def gp3_development(self, gp3_development: bool):
+    @gxtb_development.setter
+    def gxtb_development(self, gxtb_development: bool):
         """
-        Set the gp3_development flag.
+        Set the g-xTB development flag.
         """
-        if not isinstance(gp3_development, bool):
-            raise TypeError("gp3_development should be a boolean.")
-        self._gp3_development = gp3_development
+        if not isinstance(gxtb_development, bool):
+            raise TypeError("gxtb_development should be a boolean.")
+        self._gxtb_development = gxtb_development
 
     @property
-    def gp3_scf_cycles(self):
+    def gxtb_scf_cycles(self):
         """
-        Get the maximum number of SCF cycles for GP3.
+        Get the maximum number of SCF cycles for g-xTB.
         """
-        return self._gp3_scf_cycles
+        return self._gxtb_scf_cycles
 
-    @gp3_scf_cycles.setter
-    def gp3_scf_cycles(self, gp3_scf_cycles: int):
+    @gxtb_scf_cycles.setter
+    def gxtb_scf_cycles(self, gxtb_scf_cycles: int):
         """
-        Set the maximum number of SCF cycles for GP3.
+        Set the maximum number of SCF cycles for g-xTB.
         """
-        if not isinstance(gp3_scf_cycles, int):
-            raise TypeError("Max SCF cycles for GP3 should be an integer.")
-        if gp3_scf_cycles < 1:
-            raise ValueError("Max SCF cycles for GP3 should be greater than 0.")
-        self._gp3_scf_cycles = gp3_scf_cycles
+        if not isinstance(gxtb_scf_cycles, int):
+            raise TypeError("Max SCF cycles for g-xTB should be an integer.")
+        if gxtb_scf_cycles < 1:
+            raise ValueError("Max SCF cycles for g-xTB should be greater than 0.")
+        self._gxtb_scf_cycles = gxtb_scf_cycles
 
     ### End of g-xTB-specific settings #########################
     ############################################################

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -42,6 +42,13 @@ class GeneralConfig(BaseConfig):
         self._postprocess: bool = False
         self._write_xyz: bool = True
 
+        ############################################################
+        ## g-xTB-specific settings not intended for general use ####
+        self._gp3_development: bool = False
+        self._gp3_scf_cycles: int = 100
+        ### End of g-xTB-specific settings #########################
+        ############################################################
+
     def get_identifier(self) -> str:
         return "general"
 
@@ -164,6 +171,45 @@ class GeneralConfig(BaseConfig):
         if not isinstance(write_xyz, bool):
             raise TypeError("Write xyz should be a boolean.")
         self._write_xyz = write_xyz
+
+    ############################################################
+    ### g-xTB-specific settings not intended for general use ###
+    @property
+    def gp3_development(self):
+        """
+        Get the gp3_development flag.
+        """
+        return self._gp3_development
+
+    @gp3_development.setter
+    def gp3_development(self, gp3_development: bool):
+        """
+        Set the gp3_development flag.
+        """
+        if not isinstance(gp3_development, bool):
+            raise TypeError("gp3_development should be a boolean.")
+        self._gp3_development = gp3_development
+
+    @property
+    def gp3_scf_cycles(self):
+        """
+        Get the maximum number of SCF cycles for GP3.
+        """
+        return self._gp3_scf_cycles
+
+    @gp3_scf_cycles.setter
+    def gp3_scf_cycles(self, gp3_scf_cycles: int):
+        """
+        Set the maximum number of SCF cycles for GP3.
+        """
+        if not isinstance(gp3_scf_cycles, int):
+            raise TypeError("Max SCF cycles for GP3 should be an integer.")
+        if gp3_scf_cycles < 1:
+            raise ValueError("Max SCF cycles for GP3 should be greater than 0.")
+        self._gp3_scf_cycles = gp3_scf_cycles
+
+    ### End of g-xTB-specific settings #########################
+    ############################################################
 
 
 class GenerateConfig(BaseConfig):


### PR DESCRIPTION
## Optional g-xTB calculations after successful `refinement` (or `postprocessing`)

- for cation and anion separately
- if either calculation fails or # SCF iterations exceeds a set limit, don't return the `Molecule` object