### PR TITLE
Elements 87 to 103 are now accessible via the `element composition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for the novel "g-xTB" method (working title: GP3-xTB)
 - A function which contracts the coordinates after the initial generation.
 - A function which is able to printout the xyz coordinates to the terminal similar to the `.xyz` layout.
-- Elements 86 to 103 are accessible via the element composition. If `xtb` is the engine, the elements will be replaced by their lighter homologues.
+- Elements 87 to 103 are accessible via the element composition. If `xtb` is the engine, the elements will be replaced by their lighter homologues.
 
 ### Breaking Changes
 - Removal of the `dist_threshold` flag and in the `-toml` file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for the novel "g-xTB" method (working title: GP3-xTB)
 - A function which contracts the coordinates after the initial generation.
 - A function which is able to printout the xyz coordinates to the terminal similar to the `.xyz` layout.
-- The elements 86 to 103 are now accessible via the element composition.
+- Elements 86 to 103 are accessible via the element composition. If `xtb` is the engine, the elements will be replaced by their lighter homologues.
 
 ### Breaking Changes
 - Removal of the `dist_threshold` flag and in the `-toml` file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for the novel "g-xTB" method (working title: GP3-xTB)
 - A function which contracts the coordinates after the initial generation.
 - A function which is able to printout the xyz coordinates to the terminal similar to the `.xyz` layout.
+- The elements 86 to 103 are now accessible via the element composition.
 
 ### Breaking Changes
 - Removal of the `dist_threshold` flag and in the `-toml` file.

--- a/src/mindlessgen/generator/main.py
+++ b/src/mindlessgen/generator/main.py
@@ -57,9 +57,12 @@ def generator(config: ConfigManager) -> tuple[list[Molecule] | None, int]:
 
     if config.general.verbosity > 0:
         print(config)
-        config.check_config()
+
+    config.check_config(verbosity=config.general.verbosity)
 
     num_cores = min(mp.cpu_count(), config.general.parallel)
+    if config.general.verbosity > 0:
+        print(f"Running with {num_cores} cores.")
 
     # Check if the file "mindless.molecules" exists. If yes, append to it.
     if Path(MINDLESS_MOLECULES_FILE).is_file():

--- a/src/mindlessgen/generator/main.py
+++ b/src/mindlessgen/generator/main.py
@@ -8,10 +8,12 @@ from collections.abc import Callable
 from pathlib import Path
 import multiprocessing as mp
 import warnings
+import numpy as np
 
-from ..molecules import generate_random_molecule, Molecule
+from ..molecules import generate_random_molecule, Molecule, get_lanthanides
 from ..qm import XTB, get_xtb_path, QMMethod, ORCA, get_orca_path, GP3, get_gp3_path
 from ..molecules import iterative_optimization, postprocess_mol
+from ..molecules.miscellaneous import get_actinides
 from ..prog import ConfigManager
 
 from .. import __version__
@@ -209,6 +211,17 @@ def single_molecule_generator(
             config_refine=config.refine,
             verbosity=config.general.verbosity,
         )
+
+        # if np.any(np.isin(optimized_molecule.ati, get_lanthanides())):
+        #     print(config.warnings.get_warning()[0])
+        # elif np.any(np.isin(optimized_molecule.ati, get_actinides())):
+        #     print(config.warnings.get_warning()[0])
+        if np.any(np.isin(optimized_molecule.ati, get_lanthanides() + get_actinides())):
+            print(config.warnings.get_warning()[0])
+
+        if np.any(optimized_molecule.ati > 85) and postprocess_engine is None:
+            print(config.warnings.get_warning()[1])
+
     except RuntimeError as e:
         if config.general.verbosity > 0:
             print(f"Refinement failed for cycle {cycle + 1}.")

--- a/src/mindlessgen/generator/main.py
+++ b/src/mindlessgen/generator/main.py
@@ -190,7 +190,6 @@ def single_molecule_generator(
             config_refine=config.refine,
             verbosity=config.general.verbosity,
         )
-
     except RuntimeError as e:
         if config.general.verbosity > 0:
             print(f"Refinement failed for cycle {cycle + 1}.")

--- a/src/mindlessgen/generator/main.py
+++ b/src/mindlessgen/generator/main.py
@@ -212,10 +212,6 @@ def single_molecule_generator(
             verbosity=config.general.verbosity,
         )
 
-        # if np.any(np.isin(optimized_molecule.ati, get_lanthanides())):
-        #     print(config.warnings.get_warning()[0])
-        # elif np.any(np.isin(optimized_molecule.ati, get_actinides())):
-        #     print(config.warnings.get_warning()[0])
         if np.any(np.isin(optimized_molecule.ati, get_lanthanides() + get_actinides())):
             print(config.warnings.get_warning()[0])
 

--- a/src/mindlessgen/generator/main.py
+++ b/src/mindlessgen/generator/main.py
@@ -212,12 +212,6 @@ def single_molecule_generator(
             verbosity=config.general.verbosity,
         )
 
-        if np.any(np.isin(optimized_molecule.ati, get_lanthanides() + get_actinides())):
-            print(config.warnings.get_warning()[0])
-
-        if np.any(optimized_molecule.ati > 85) and postprocess_engine is None:
-            print(config.warnings.get_warning()[1])
-
     except RuntimeError as e:
         if config.general.verbosity > 0:
             print(f"Refinement failed for cycle {cycle + 1}.")
@@ -247,6 +241,16 @@ def single_molecule_generator(
                 stop_event.set()  # Stop further runs if debugging of this step is enabled
         if config.general.verbosity > 1:
             print("Postprocessing successful.")
+
+    if isinstance(refine_engine, XTB):
+        if np.any(np.isin(optimized_molecule.ati, get_lanthanides() + get_actinides())):
+            print(config.warnings.get_warning()[0])
+
+        if np.any(optimized_molecule.ati > 85):
+            print(config.warnings.get_warning()[1])
+
+        if postprocess_engine is None:
+            print(config.warnings.get_warning()[2])
 
     if not stop_event.is_set():
         stop_event.set()  # Signal other processes to stop

--- a/src/mindlessgen/molecules/miscellaneous.py
+++ b/src/mindlessgen/molecules/miscellaneous.py
@@ -16,14 +16,15 @@ def set_random_charge(ati: np.ndarray, verbosity: int = 1) -> tuple[int, int]:
     if verbosity > 1:
         print(f"Number of protons in molecule: {nel}")
 
-    if np.any(np.isin(ati, get_lanthanides())):
-        ### Special mode for lanthanides
+    if np.any(np.isin(ati, get_lanthanides() + get_actinides())):
+        ### Special mode for lanthanides and actinides
         # -> always high spin
-        # -> Divide the molecule into Ln3+ ions and negative "ligands"
+        # -> Divide the molecule into Ln3+/Ac3+ ions and negative "ligands"
         # -> The ligands are the remaining protons are assumed to be low spin
         uhf = 0
         charge = 0
         ln_protons = 0
+        ac_protons = 0
         for atom in ati:
             if atom in get_lanthanides():
                 if atom < 64:
@@ -33,9 +34,20 @@ def set_random_charge(ati: np.ndarray, verbosity: int = 1) -> tuple[int, int]:
                 ln_protons += (
                     atom - 3 + 1
                 )  # subtract 3 to get the number of protons in the Ln3+ ion
-        ligand_protons = nel - ln_protons
+            if atom in get_actinides():
+                if atom < 96:
+                    uhf += atom - 88
+                else:
+                    uhf += 102 - atom
+                ac_protons += (
+                    atom - 3 + 1
+                )  # subtract 3 to get the number of protons in the Ln3+ ion
+        ligand_protons = nel - ln_protons - ac_protons
         if verbosity > 2:
-            print(f"Number of protons from Ln^3+ ions: {ln_protons}")
+            if np.any(np.isin(ati, get_lanthanides())):
+                print(f"Number of protons from Ln^3+ ions: {ln_protons}")
+            if np.any(np.isin(ati, get_actinides())):
+                print(f"Number of protons from Ac^3+ ions: {ac_protons}")
             print(
                 f"Number of protons from ligands (assuming negative charge): {ligand_protons}"
             )

--- a/src/mindlessgen/molecules/miscellaneous.py
+++ b/src/mindlessgen/molecules/miscellaneous.py
@@ -34,7 +34,7 @@ def set_random_charge(ati: np.ndarray, verbosity: int = 1) -> tuple[int, int]:
                 ln_protons += (
                     atom - 3 + 1
                 )  # subtract 3 to get the number of protons in the Ln3+ ion
-            if atom in get_actinides():
+            elif atom in get_actinides():
                 if atom < 96:
                     uhf += atom - 88
                 else:

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -716,6 +716,36 @@ class ORCAConfig(BaseConfig):
         self._scf_cycles = max_scf_cycles
 
 
+class WarningConfig:
+    """
+    This class handles warnings related to xTB calculations.
+    """
+
+    def __init__(self) -> None:
+        self.warnings = [
+            "WARNING: f-block elements are within the molecule. xTB does not treat f electrons explicitly. UHF is set to 0.",
+            "WARNING: Super heavy elements are within the molecule. xTB does not treat super havy elements. Atomic numbers are reduced by 32. Postproccessing is turned off the structure will not be relaxed.",
+        ]
+
+    def add_warning(self, warning: str) -> None:
+        """
+        Add a warning to the list of warnings.
+        """
+        self.warnings.append(warning)
+
+    def get_warning(self) -> list[str]:
+        """
+        Get the list of warnings.
+        """
+        return self.warnings
+
+    def clear_warning(self) -> None:
+        """
+        Clear all warnings.
+        """
+        self.warnings.clear()
+
+
 class ConfigManager:
     """
     Overall configuration manager for the program.
@@ -731,6 +761,7 @@ class ConfigManager:
         self.refine = RefineConfig()
         self.postprocess = PostProcessConfig()
         self.generate = GenerateConfig()
+        self.warnings = WarningConfig()
 
         if config_file:
             self.load_from_toml(config_file)

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -759,40 +759,43 @@ class ConfigManager:
                 + "Don't be confused!"
             )
 
-        if verbosity > 0:
-            if num_cores > 1:
-                # raise warning that parallelization will disable verbosity
-                warnings.warn(
-                    "Parallelization will disable verbosity during iterative search. "
-                    + "Set '--verbosity 0' or '-P 1' to avoid this warning, or simply ignore it."
-                )
+        if num_cores > 1 and verbosity > 0:
+            # raise warning that parallelization will disable verbosity
+            warnings.warn(
+                "Parallelization will disable verbosity during iterative search. "
+                + "Set '--verbosity 0' or '-P 1' to avoid this warning, or simply ignore it."
+            )
 
-            # Check for f-block elements in forbidden elements
-            if self.generate.forbidden_elements:
-                f_block_elements = set(range(56, 70)) | set(range(88, 102))
-                if any(
-                    elem not in f_block_elements
-                    for elem in self.generate.forbidden_elements
+        # Check for f-block elements in forbidden elements
+        if self.generate.forbidden_elements:
+            if verbosity > 0:
+                f_block_elements = set(range(56, 71)) | set(range(88, 103))
+                if not all(
+                    elem in self.generate.forbidden_elements
+                    for elem in f_block_elements
+                ) or any(
+                    elem in f_block_elements
+                    for elem in self.generate.element_composition
                 ):
                     warnings.warn(
                         "f-block elements could be within the molecule. xTB does not treat f electrons explicitly. In this case UHF is set to 0."
                     )
 
-            # Check for super heavy elements in forbidden elements
-            super_heavy_elements = set(range(86, 102))
-            if self.generate.element_composition and any(
-                elem in super_heavy_elements
-                for elem in self.generate.element_composition
-            ):
+        # Check for super heavy elements in forbidden elements
+        super_heavy_elements = set(range(86, 102))
+        if self.generate.element_composition and any(
+            elem in super_heavy_elements for elem in self.generate.element_composition
+        ):
+            if verbosity > 0:
                 warnings.warn(
                     "xTB does not treat super heavy elements. Atomic numbers are temporarily reduced by 32 to their lighter homologues and then replaced with the correct atom number."
                 )
 
-            # Check if postprocessing is turned off
-            if not self.general.postprocess and any(
-                elem in super_heavy_elements
-                for elem in self.generate.element_composition
-            ):
+        # Check if postprocessing is turned off
+        if not self.general.postprocess and any(
+            elem in super_heavy_elements for elem in self.generate.element_composition
+        ):
+            if verbosity > 0:
                 warnings.warn(
                     "Postprocessing is turned off. The structure will not be relaxed."
                 )

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -724,26 +724,15 @@ class WarningConfig:
     def __init__(self) -> None:
         self.warnings = [
             "WARNING: f-block elements are within the molecule. xTB does not treat f electrons explicitly. UHF is set to 0.",
-            "WARNING: Super heavy elements are within the molecule. xTB does not treat super havy elements. Atomic numbers are reduced by 32. Postproccessing is turned off the structure will not be relaxed.",
+            "WARNING: Super heavy elements are within the molecule. xTB does not treat super havy elements. Atomic numbers are reduced by 32.",
+            "WARNING: Postproccessing is turned off the structure will not be relaxed.",
         ]
-
-    def add_warning(self, warning: str) -> None:
-        """
-        Add a warning to the list of warnings.
-        """
-        self.warnings.append(warning)
 
     def get_warning(self) -> list[str]:
         """
         Get the list of warnings.
         """
         return self.warnings
-
-    def clear_warning(self) -> None:
-        """
-        Clear all warnings.
-        """
-        self.warnings.clear()
 
 
 class ConfigManager:

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -785,7 +785,7 @@ class ConfigManager:
                 for elem in self.generate.element_composition
             ):
                 warnings.warn(
-                    "xTB does not treat super heavy elements. Approximation: atomic numbers are reduced by 32. MindlesGen terminates normally."
+                    "xTB does not treat super heavy elements. Atomic numbers are temporarily reduced by 32 to their lighter homologues and then replaced with the correct atom number."
                 )
 
             # Check if postprocessing is turned off

--- a/src/mindlessgen/qm/xtb.py
+++ b/src/mindlessgen/qm/xtb.py
@@ -90,7 +90,6 @@ class XTB(QMMethod):
             if super_heavy_elements:
                 # Reset the atomic numbers to the original values before returning the optimized molecule.
                 optimized_molecule.ati = ati_original
-                molecule.ati = ati_original
                 optimized_molecule.atlist = molecule.atlist
             return optimized_molecule
 

--- a/src/mindlessgen/qm/xtb.py
+++ b/src/mindlessgen/qm/xtb.py
@@ -36,6 +36,12 @@ class XTB(QMMethod):
         """
         Optimize a molecule using xtb.
         """
+        super_heavy_elements = False
+        ati_original = molecule.ati.copy()
+        if np.any(molecule.ati > 85):
+            super_heavy_elements = True
+            molecule.ati[molecule.ati > 85] -= 32
+
         if np.any(np.isin(molecule.ati, get_lanthanides())):
             check_ligand_uhf(molecule.ati, molecule.charge)
             # Store the original UHF value and set uhf to 0
@@ -82,12 +88,21 @@ class XTB(QMMethod):
             if np.any(np.isin(molecule.ati, get_lanthanides())):
                 # Reset the UHF value to the original value before returning the optimized molecule.
                 optimized_molecule.uhf = uhf_original
+            if super_heavy_elements:
+                # Reset the atomic numbers to the original values before returning the optimized molecule.
+                optimized_molecule.ati = ati_original
+                molecule.ati = ati_original
             return optimized_molecule
 
     def singlepoint(self, molecule: Molecule, verbosity: int = 1) -> str:
         """
         Perform a single-point calculation using xtb.
         """
+        super_heavy_elements = False
+        ati_original = molecule.ati.copy()
+        if np.any(molecule.ati > 85):
+            super_heavy_elements = True
+            molecule.ati[molecule.ati > 85] -= 32
         if np.any(np.isin(molecule.ati, get_lanthanides())):
             check_ligand_uhf(molecule.ati, molecule.charge)
             # Store the original UHF value and set uhf to 0
@@ -128,6 +143,9 @@ class XTB(QMMethod):
 
             if np.any(np.isin(molecule.ati, get_lanthanides())):
                 molecule.uhf = uhf_original
+            if super_heavy_elements:
+                # Reset the atomic numbers to the original values before returning the optimized molecule.
+                molecule.ati = ati_original
             return xtb_log_out
 
     def check_gap(

--- a/src/mindlessgen/qm/xtb.py
+++ b/src/mindlessgen/qm/xtb.py
@@ -41,7 +41,6 @@ class XTB(QMMethod):
         if np.any(molecule.ati > 85):
             super_heavy_elements = True
             molecule.ati[molecule.ati > 85] -= 32
-
         if np.any(np.isin(molecule.ati, get_lanthanides())):
             check_ligand_uhf(molecule.ati, molecule.charge)
             # Store the original UHF value and set uhf to 0
@@ -92,6 +91,7 @@ class XTB(QMMethod):
                 # Reset the atomic numbers to the original values before returning the optimized molecule.
                 optimized_molecule.ati = ati_original
                 molecule.ati = ati_original
+                optimized_molecule.atlist = molecule.atlist
             return optimized_molecule
 
     def singlepoint(self, molecule: Molecule, verbosity: int = 1) -> str:

--- a/test/test_molecules/test_miscellaneous.py
+++ b/test/test_molecules/test_miscellaneous.py
@@ -37,7 +37,18 @@ from mindlessgen.molecules.miscellaneous import set_random_charge  # type: ignor
             7,
         ),  # Gd (64), C, C -> Lanthanide case, UHF = 7, CHRG = 1
         (np.array([57, 7, 0]), [0], 1),  # Ce (58), O, H -> Lanthanide case, UHF = 1
-        (np.array([69, 7, 0]), [0], 1),  # Ce (58), O, H -> Lanthanide case, UHF = 1
+        (np.array([69, 7, 0]), [0], 1),  # Yb (70), O, H -> Lanthanide case, UHF = 1
+        (np.array([5, 7, 0, 98]), [0], 4),  # Es(99), O, C, H -> Actinides case, UHF = 4
+        (
+            np.array([59, 92, 0, 0]),
+            [0],
+            7,
+        ),  # Nd(60), Np(93), H, H -> Lanthanide and Actinide case, UHF = 7
+        (
+            np.array([59, 91, 92, 5, 7, 0]),
+            [0],
+            10,
+        ),  # Nd(60), U(92), Np(93), H, H -> Lanthanide and Actinides case, UHF = 10
     ],
     ids=[
         "B-N-H (standard, odd)",
@@ -49,6 +60,9 @@ from mindlessgen.molecules.miscellaneous import set_random_charge  # type: ignor
         "Gd-C-N (lanthanide)",
         "Ce-O-H (lanthanide)",
         "Yb-O-H (lanthanide)",
+        "Es-O-C-H (actinides)",
+        "Nd-Np-H-H (lanthanide and actinide)",
+        "Nd-Eu-Np-H-H (lanthanide and actinides)",
     ],
 )
 def test_set_random_charge(atom_types, expected_charges, expected_uhf):


### PR DESCRIPTION
Elements from 87 to 103 can now be integrated into the molecule when they are labeled in the element composition section. When the refinement engine is `xtb`, the element is replaced by the lighter homologues. For the post process the element replacement is reverted.