### PR TITLE
Bunch of technical fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ There are two related aspects of the element composition:
 - **Example 1**: `C:1-3, O:1-1, H:1-*` would result in a molecule with 1, 2, or 3 carbon atoms, exactly 1 oxygen atom, and between 1 and an undefined number of hydrogen atoms (i.e., at least 1).
 - **Example 2**: `Na:10-10, In:10-10, O:20-20`. This example would result in a molecule with exactly 10 sodium atoms, 10 indium atoms, and 20 oxygen atoms. **For a fixed element composition, the number of atoms (40) has to be within the min_num_atoms and max_num_atom interval.** `mindlessgen` will consequently always return a molecule with exactly 40 atoms.
 
+> [!WARNING]
+> When using `orca` and specifying elements with `Z > 86`, ensure that the basis set you've selected is compatible with (super-)heavy elements like actinides.
+> You can find a list of available basis sets [here](https://www.faccts.de/docs/orca/6.0/manual/contents/detailed/basisset.html#built-in-basis-sets).
+> A reliable standard choice that covers the entire periodic table is `def2-mTZVPP`.
+
 ## Citation
 
 When using the program for academic purposes, please cite:

--- a/src/mindlessgen/molecules/__init__.py
+++ b/src/mindlessgen/molecules/__init__.py
@@ -17,6 +17,7 @@ from .miscellaneous import (
     get_four_d_metals,
     get_five_d_metals,
     get_lanthanides,
+    get_actinides,
     get_alkali_metals,
     get_alkaline_earth_metals,
 )
@@ -34,6 +35,7 @@ __all__ = [
     "get_four_d_metals",
     "get_five_d_metals",
     "get_lanthanides",
+    "get_actinides",
     "get_alkali_metals",
     "get_alkaline_earth_metals",
     "PSE_NUMBERS",

--- a/src/mindlessgen/molecules/molecule.py
+++ b/src/mindlessgen/molecules/molecule.py
@@ -246,7 +246,7 @@ class Molecule:
         molecule = Molecule()
         if isinstance(file, str):
             file_path = Path(file).resolve()
-        if isinstance(file, Path):
+        elif isinstance(file, Path):
             file_path = file.resolve()
         else:
             raise TypeError("String or Path expected.")

--- a/src/mindlessgen/molecules/molecule.py
+++ b/src/mindlessgen/molecules/molecule.py
@@ -248,6 +248,8 @@ class Molecule:
             file_path = Path(file).resolve()
         if isinstance(file, Path):
             file_path = file.resolve()
+        else:
+            raise TypeError("String or Path expected.")
         molecule.read_xyz_from_file(file_path)
         if file_path.with_suffix(".CHRG").exists():
             molecule.read_charge_from_file(file_path.with_suffix(".CHRG"))

--- a/src/mindlessgen/qm/orca.py
+++ b/src/mindlessgen/qm/orca.py
@@ -165,6 +165,9 @@ class ORCA(QMMethod):
         orca_input = f"! {self.cfg.functional} {self.cfg.basis}\n"
         orca_input += f"! DEFGRID{self.cfg.gridsize}\n"
         orca_input += "! NoTRAH NoSOSCF SlowConv\n"
+        # "! AutoAux" keyword for super-heavy elements as def2/J ends at Rn
+        if any(atom >= 86 for atom in molecule.ati):
+            orca_input += "! AutoAux\n"
         if optimization:
             orca_input += "! OPT\n"
             if opt_cycles is not None:

--- a/src/mindlessgen/qm/xtb.py
+++ b/src/mindlessgen/qm/xtb.py
@@ -205,12 +205,12 @@ class XTB(QMMethod):
                 check=True,
             )
             # get the output of the xtb calculation (of both stdout and stderr)
-            xtb_log_out = xtb_out.stdout.decode("utf8")
-            xtb_log_err = xtb_out.stderr.decode("utf8")
+            xtb_log_out = xtb_out.stdout.decode("utf8", errors="replace")
+            xtb_log_err = xtb_out.stderr.decode("utf8", errors="replace")
             return xtb_log_out, xtb_log_err, 0
         except sp.CalledProcessError as e:
-            xtb_log_out = e.stdout.decode("utf8")
-            xtb_log_err = e.stderr.decode("utf8")
+            xtb_log_out = e.stdout.decode("utf8", errors="replace")
+            xtb_log_err = e.stderr.decode("utf8", errors="replace")
             return xtb_log_out, xtb_log_err, e.returncode
 
 


### PR DESCRIPTION
- include missing `__init__.py` entry
- Standard auxiliary basis set in `orca` does not work for heavier elements
- hint in `README.md` regarding the basis set choice
- follow linter warning