### PR TITLE
Fix bug with Lr leading to an 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit conversion for (currenly unused) vdW radii from the original Fortran project
 - minor print output issues (no new line breaks, more consistent verbosity differentiation, ...)
 - bug in `postprocess_mol` which led to an unassigned return variable in the single-point case
+- bug with all atom lists being initialized with a length of 102 instead of 103
 
 ### Added
 - Support for the novel "g-xTB" method (working title: GP3-xTB)

--- a/src/mindlessgen/molecules/generate_molecule.py
+++ b/src/mindlessgen/molecules/generate_molecule.py
@@ -73,8 +73,8 @@ def generate_atom_list(cfg: GenerateConfig, verbosity: int = 1) -> np.ndarray:
         valid_elems = set_all_elem
 
     natoms = np.zeros(
-        102, dtype=int
-    )  # 102 is the number of accessible elements in the periodic table
+        103, dtype=int
+    )  # 103 is the number of accessible elements in the periodic table
 
     # Some sanity checks:
     # - Check if the minimum number of atoms is smaller than the maximum number of atoms

--- a/src/mindlessgen/molecules/molecule.py
+++ b/src/mindlessgen/molecules/molecule.py
@@ -545,7 +545,7 @@ class Molecule:
             # read the atomic coordinates
             self.xyz = np.zeros((self.num_atoms, 3))
             self.ati = np.zeros(self.num_atoms, dtype=int)
-            self.atlist = np.zeros(102, dtype=int)
+            self.atlist = np.zeros(103, dtype=int)
             for i in range(self.num_atoms):
                 line = lines[i + 2].split()
                 self.ati[i] = PSE_NUMBERS[line[0].lower()] - 1

--- a/src/mindlessgen/molecules/refinement.py
+++ b/src/mindlessgen/molecules/refinement.py
@@ -197,7 +197,7 @@ def detect_fragments(
         # Remove the atoms that are not in the fragment from ati
         fragment_molecule.ati = np.array([mol.ati[i] for i in fragment])
         # Update atlist by going through ati and add the occurences of each atom onto an empty array
-        fragment_molecule.atlist = np.zeros(102, dtype=int)
+        fragment_molecule.atlist = np.zeros(103, dtype=int)
         for atom in fragment_molecule.ati:
             fragment_molecule.atlist[atom] += 1
         # Update the charge of the fragment molecule

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -779,7 +779,9 @@ class ConfigManager:
                         for elem in self.generate.element_composition
                     ):
                         warnings.warn(
-                            "f-block elements could be within the molecule. xTB does not treat f electrons explicitly. In this case UHF is set to 0."
+                            "f-block elements could be within the molecule. "
+                            + "xTB does not treat f electrons explicitly. "
+                            + "UHF is temporarily set to 0."
                         )
 
             # Check for super heavy elements in forbidden elements

--- a/test/test_generate/test_generate_molecule.py
+++ b/test/test_generate/test_generate_molecule.py
@@ -35,7 +35,7 @@ def test_generate_atom_list(min_atoms, max_atoms, default_generate_config):
 
     # Common assertions for atom count range
     assert isinstance(atom_list, np.ndarray)
-    assert atom_list.shape == (102,)
+    assert atom_list.shape == (103,)
     assert np.sum(atom_list) > 0
     assert np.sum(atom_list) >= min_atoms
     assert np.sum(atom_list) <= max_atoms


### PR DESCRIPTION
- fix bug with Lr leading to an "out of bounds" error: atom list should have 103, and not 102 entries (when trying to include actinides completely

This was the error, I've received (from SG):
```
✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
 File "/home/grimme/miniforge3/envs/mindlessgen/lib/python3.12/multiprocessing/pool.py", line 125, in worker
   result = (True, func(*args, **kwds))
                   ^^^^^^^^^^^^^^^^^^^
 File "/home/grimme/miniforge3/envs/mindlessgen/lib/python3.12/multiprocessing/pool.py", line 51, in starmapstar
   return list(itertools.starmap(args[0], args[1]))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/home/grimme/source/MindlessGen/src/mindlessgen/generator/main.py", line 164, in single_molecule_generator
   mol = generate_random_molecule(config.generate, config.general.verbosity)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/home/grimme/source/MindlessGen/src/mindlessgen/molecules/generate_molecule.py", line 32, in generate_random_molecule
   mol.atlist = generate_atom_list(
                ^^^^^^^^^^^^^^^^^^^
 File "/home/grimme/source/MindlessGen/src/mindlessgen/molecules/generate_molecule.py", line 321, in generate_atom_list
   check_composition()
 File "/home/grimme/source/MindlessGen/src/mindlessgen/molecules/generate_molecule.py", line 302, in check_composition
   if min_count is not None and natoms[elem] < min_count:
                                ~~~~~~^^^^^^
IndexError: index 102 is out of bounds for axis 0 with size 102
```

@jonathan-schoeps Should be something for you, please verify and check if that's the appropriate fix.