### PR TITLE
The `.UHF` file is now written if the molecule has a uhf larger than 0

### DIFF
--- a/src/mindlessgen/molecules/molecule.py
+++ b/src/mindlessgen/molecules/molecule.py
@@ -150,8 +150,8 @@ class Molecule:
         self._name = name
 
         self._num_atoms: int | None = None
-        self._charge: int
-        self._uhf: int
+        self._charge: int | None = None
+        self._uhf: int | None = None
         self._atlist: np.ndarray = np.array([], dtype=int)
         self._xyz: np.ndarray = np.array([], dtype=float)
         self._ati: np.ndarray = np.array([], dtype=int)
@@ -519,11 +519,11 @@ class Molecule:
         with open(filename, "w", encoding="utf8") as f:
             f.write(self.get_xyz_str())
         # if the charge is set, write it to a '.CHRG' file
-        if self._charge > 0:
+        if self._charge is not None and self._charge > 0:
             with open(filename.with_suffix(".CHRG"), "w", encoding="utf8") as f:
                 f.write(f"{self.charge}\n")
         # if the UHF is set, write it to a '.UHF' file
-        if self._uhf > 0:
+        if self._uhf is not None and self._uhf > 0:
             with open(filename.with_suffix(".UHF"), "w", encoding="utf8") as f:
                 f.write(f"{self.uhf}\n")
 

--- a/src/mindlessgen/molecules/molecule.py
+++ b/src/mindlessgen/molecules/molecule.py
@@ -150,7 +150,7 @@ class Molecule:
         self._name = name
 
         self._num_atoms: int | None = None
-        self._charge: int | None = None
+        self._charge: int
         self._uhf: int
         self._atlist: np.ndarray = np.array([], dtype=int)
         self._xyz: np.ndarray = np.array([], dtype=float)
@@ -517,7 +517,7 @@ class Molecule:
         with open(filename, "w", encoding="utf8") as f:
             f.write(self.get_xyz_str())
         # if the charge is set, write it to a '.CHRG' file
-        if self._charge is not None:
+        if self._charge > 0:
             with open(filename.with_suffix(".CHRG"), "w", encoding="utf8") as f:
                 f.write(f"{self.charge}\n")
         # if the UHF is set, write it to a '.UHF' file

--- a/src/mindlessgen/molecules/molecule.py
+++ b/src/mindlessgen/molecules/molecule.py
@@ -151,7 +151,7 @@ class Molecule:
 
         self._num_atoms: int | None = None
         self._charge: int | None = None
-        self._uhf: int | None = None
+        self._uhf: int
         self._atlist: np.ndarray = np.array([], dtype=int)
         self._xyz: np.ndarray = np.array([], dtype=float)
         self._ati: np.ndarray = np.array([], dtype=int)
@@ -521,7 +521,7 @@ class Molecule:
             with open(filename.with_suffix(".CHRG"), "w", encoding="utf8") as f:
                 f.write(f"{self.charge}\n")
         # if the UHF is set, write it to a '.UHF' file
-        if self._uhf is not None:
+        if self._uhf > 0:
             with open(filename.with_suffix(".UHF"), "w", encoding="utf8") as f:
                 f.write(f"{self.uhf}\n")
 

--- a/src/mindlessgen/molecules/molecule.py
+++ b/src/mindlessgen/molecules/molecule.py
@@ -519,7 +519,7 @@ class Molecule:
         with open(filename, "w", encoding="utf8") as f:
             f.write(self.get_xyz_str())
         # if the charge is set, write it to a '.CHRG' file
-        if self._charge is not None and self._charge > 0:
+        if self._charge is not None and self._charge != 0:
             with open(filename.with_suffix(".CHRG"), "w", encoding="utf8") as f:
                 f.write(f"{self.charge}\n")
         # if the UHF is set, write it to a '.UHF' file


### PR DESCRIPTION
The `.UHF` file is now only written if the molecule has `uhf > 0`. This should make it more convenient to use `MindlessGen` together with `g-xTB`.