### PR TITLE
Remove deprecated tests that are not strictly true

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,7 +5,6 @@ Setup for pytest.
 import numpy as np
 import pytest
 
-np.random.seed(0)
 np.set_printoptions(precision=16)
 
 

--- a/test/test_generate/test_generate_molecule.py
+++ b/test/test_generate/test_generate_molecule.py
@@ -40,19 +40,6 @@ def test_generate_atom_list(min_atoms, max_atoms, default_generate_config):
     assert np.sum(atom_list) >= min_atoms
     assert np.sum(atom_list) <= max_atoms
 
-    # Check that the sum of transition and lanthanide metals is never greater than 3
-    all_metals = (
-        get_three_d_metals()
-        + get_four_d_metals()
-        + get_five_d_metals()
-        + get_lanthanides()
-    )
-    assert np.sum([atom_list[z] for z in all_metals]) <= 3
-
-    # Check that the sum of alkali and alkaline earth metals is never greater than 3
-    alkmetals = get_alkali_metals() + get_alkaline_earth_metals()
-    assert np.sum([atom_list[z] for z in alkmetals]) <= 3
-
 
 # Test the element composition property of the GenerateConfig class
 def test_generate_config_element_composition(default_generate_config):


### PR DESCRIPTION
The attached log shows a regularly failing test: 
```python
def test_generate_atom_list(min_atoms, max_atoms, default_generate_config):
```

The check for the number of metal atoms in a strict sense does not make sense as random atom types are added if the number of atoms before finalizing the atom list is below `min_num_atoms`.
Since exact compositions can be defined and element types can be forbidden completely, the reduction of metal atoms during completely random generation should rather be seen as a "push" towards feasible systems than a strict border. That's why we should just delete those tests.

[5_tox (windows-latest, 3.11).txt](https://github.com/user-attachments/files/17756673/5_tox.windows-latest.3.11.txt)
