### PR TITLE
Random integer in `element_composition` range

### DIFF
--- a/src/mindlessgen/molecules/generate_molecule.py
+++ b/src/mindlessgen/molecules/generate_molecule.py
@@ -325,10 +325,17 @@ def generate_atom_list(cfg: GenerateConfig, verbosity: int = 1) -> np.ndarray:
         # CAUTION: The setting to min/max count may violate the metal count restrictions
         for elem, count_range in cfg.element_composition.items():
             min_count, max_count = count_range
-            if min_count is not None and natoms[elem] < min_count:
-                natoms[elem] = min_count
-            elif max_count is not None and natoms[elem] > max_count:
-                natoms[elem] = max_count
+            # define the random number of atoms to be added
+            if min_count is None:
+                min_count = 0
+            if max_count is None:
+                max_count = cfg.max_num_atoms
+                # 50 % of the maximally allowed number of atoms
+            added_atoms_from_composition = rng.integers(
+                low=min_count, high=max_count, endpoint=True
+            )
+            natoms[elem] = added_atoms_from_composition
+            print(f"Adding {added_atoms_from_composition} atoms of type {elem}...")
 
     ### ACTUAL WORKFLOW START ###
     # Add a random number of atoms of random types


### PR DESCRIPTION
### Before

Only correction of the atom list toward the lower (happened 99 % of the time) or lower limit.

### Now

Take a random integer in the desired range so that the whole range is covered.