### PR TITLE
Full pythonization of `element_composition` and `forbidden_elements`

### DIFF
--- a/src/mindlessgen/molecules/molecule.py
+++ b/src/mindlessgen/molecules/molecule.py
@@ -10,7 +10,7 @@ import numpy as np
 from ..__version__ import __version__
 
 
-PSE = {
+PSE: dict[int, str] = {
     0: "X",
     1: "H",
     2: "He",

--- a/test/test_config/test_config_set_attributes.py
+++ b/test/test_config/test_config_set_attributes.py
@@ -91,12 +91,16 @@ def test_generate_config_property_setters(
     [
         ("element_composition", "C:1-10", {5: (1, 10)}),
         ("element_composition", "C:1-10, H:2-*", {5: (1, 10), 0: (2, None)}),
+        # additional test for giving the element_composition directly as a dictionary
+        ("element_composition", {5: (1, 10), 0: (2, None)}, {5: (1, 10), 0: (2, None)}),
         ("forbidden_elements", "6,1", [0, 5]),
         (
             "forbidden_elements",
             "86-*",
             [85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102],
         ),
+        # additional test for giving the forbidden_elements directly as a list
+        ("forbidden_elements", [0, 5], [0, 5]),
     ],
 )
 def test_generate_config_element_composition(


### PR DESCRIPTION
- direct access of `dict` and `list` attributes behind the `setter` object. Valuable for Python API access, because parsing information into a string back and forth can be avoided
- some type hint updates (should be more concise and correct)