### PR TITLE
Element composition dict with str and mixed keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- to set the elemental composition it is now possible to use dicts with not only int but also the element symbols (str)
+- dict keys for elemental compositions will now always be checked for validity
 
 ## [0.5.0] - 2024-12-16
 ### Changed

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ def main():
     config.generate.max_num_atoms = 15
     config.generate.element_composition = "Ce:1-1"
     # alternatively as a dictionary: config.generate.element_composition = {39:(1,1)}
+    # or: config.generate.element_composition = {"Ce":(1,1)"}
+    # or as mixed-key dict, e.g. for Ce and O: {"Ce":(1,1), 7:(2,2)}
     config.generate.forbidden_elements = "21-30,39-48,57-80"
     # alternatively as a list: config.generate.forbidden_elements = [20,21,22,23] # 24,25,26...
 

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -342,7 +342,7 @@ class GenerateConfig(BaseConfig):
                     tmp[element_number - 1] = composition[key]
                 # Check int keys
                 else:
-                    if key in PSE_SYMBOLS:
+                    if key + 1 in PSE_SYMBOLS:
                         tmp[key] = composition[key]
                     else:
                         raise KeyError(

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -299,7 +299,8 @@ class GenerateConfig(BaseConfig):
             Parses the element_composition string and stores the parsed data
             in the _element_composition dictionary.
             Format: "C:2-10, H:10-20, O:1-5, N:1-*"
-        If composition_str: dict, it should be a dictionary with integer/string keys and tuple values. Will be stored as is.
+        If composition: dict:
+            Should be a dictionary with integer/string keys and tuple values. Will be stored as is.
 
         Arguments:
             composition_str (str): String with the element composition

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -346,7 +346,7 @@ class GenerateConfig(BaseConfig):
                         tmp[key] = composition[key]
                     else:
                         raise KeyError(
-                            f"Element with atomic number {key} not found in the periodic table."
+                            f"Element with atomic number {key+1} (provided key: {key}) not found in the periodic table."
                         )
             self._element_composition = tmp
             return

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -335,7 +335,6 @@ class GenerateConfig(BaseConfig):
                 # Convert str keys
                 if isinstance(key, str):
                     element_number = PSE_NUMBERS.get(key.lower(), None)
-                    print(key, element_number)
                     if element_number is None:
                         raise KeyError(
                             f"Element {key} not found in the periodic table."
@@ -349,7 +348,6 @@ class GenerateConfig(BaseConfig):
                         raise KeyError(
                             f"Element with atomic number {key} not found in the periodic table."
                         )
-            print(tmp)
             self._element_composition = tmp
             return
 

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -295,7 +295,7 @@ class GenerateConfig(BaseConfig):
         self, composition: None | str | dict[int | str, tuple[int | None, int | None]]
     ) -> None:
         """
-        If composition_str: str, it should be a string with the format:
+        If composition: str:
             Parses the element_composition string and stores the parsed data
             in the _element_composition dictionary.
             Format: "C:2-10, H:10-20, O:1-5, N:1-*"

--- a/test/test_generate/test_generate_molecule.py
+++ b/test/test_generate/test_generate_molecule.py
@@ -41,12 +41,66 @@ def test_generate_atom_list(min_atoms, max_atoms, default_generate_config):
     assert np.sum(atom_list) <= max_atoms
 
 
-# Test the element composition property of the GenerateConfig class
-def test_generate_config_element_composition(default_generate_config):
-    """Test the element composition property of the GenerateConfig class."""
+# Test the element composition property of the GenerateConfig class with a composition string
+def test_generate_config_element_composition_string(default_generate_config):
+    """Test the element composition property of the GenerateConfig class with a composition string."""
     default_generate_config.min_num_atoms = 10
     default_generate_config.max_num_atoms = 15
     default_generate_config.element_composition = "C:2-2, N:3-3, O:1-1"
+    atom_list = generate_atom_list(default_generate_config, verbosity=1)
+
+    # Check that the atom list contains the correct number of atoms for each element
+    assert atom_list[5] == 2
+    assert atom_list[6] == 3
+    assert atom_list[7] == 1
+
+
+# Test the element composition property of the GenerateConfig class with an int key composition dict
+def test_generate_config_element_composition_dict_int(default_generate_config):
+    """Test the element composition property of the GenerateConfig class with an int key composition dict."""
+
+    # Pure int keys
+    default_generate_config.min_num_atoms = 10
+    default_generate_config.max_num_atoms = 15
+    default_generate_config.element_composition = {
+        5: (2, 2),
+        6: (3, 3),
+        7: (1, 1),
+    }  # NOTE: mind 0-based indexing for atomic numbers
+    atom_list = generate_atom_list(default_generate_config, verbosity=1)
+
+    # Check that the atom list contains the correct number of atoms for each element
+    assert atom_list[5] == 2
+    assert atom_list[6] == 3
+    assert atom_list[7] == 1
+
+
+# Test the element composition property of the GenerateConfig class with an int key composition dict
+def test_generate_config_element_composition_dict_string(default_generate_config):
+    """Test the element composition property of the GenerateConfig class with a str key composition dict."""
+
+    default_generate_config.min_num_atoms = 10
+    default_generate_config.max_num_atoms = 15
+    default_generate_config.element_composition = {
+        "C": (2, 2),
+        "N": (3, 3),
+        "O": (1, 1),
+    }
+    atom_list = generate_atom_list(default_generate_config, verbosity=1)
+
+    # Check that the atom list contains the correct number of atoms for each element
+    assert atom_list[5] == 2
+    assert atom_list[6] == 3
+    assert atom_list[7] == 1
+
+
+# Test the element composition property of the GenerateConfig class with an int key composition dict
+def test_generate_config_element_composition_dict_mixed(default_generate_config):
+    """Test the element composition property of the GenerateConfig class with a str key composition dict."""
+
+    default_generate_config.min_num_atoms = 10
+    default_generate_config.max_num_atoms = 15
+    default_generate_config.element_composition = {5: (2, 2), "N": (3, 3), "O": (1, 1)}
     atom_list = generate_atom_list(default_generate_config, verbosity=1)
 
     # Check that the atom list contains the correct number of atoms for each element


### PR DESCRIPTION
* added the capability to use composition dicts with string keys instead of atomic number keys, as well as mixed keys
* added test cases for dict[int, tuple[int, int]], dict[str, tuple[int, int]], dict[str | int, tuple[int, int]]
* added check for validity of provided atomic numbers in composition dict (check, if atomic number in PSE table)
* side-effect is that element composition is effectively a copy of the input argument, protecting the attribute from possibly unwanted changes due to passing by reference when using a dict as input