### PR TITLE
Fix reading error in `_run_opt` of `Turbomole` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - version string is now correctly formatted and printed
 - precision (# significant digits) of the coordinate files (`get_coord_str` and `get_xyz_str`) increased from 7 to 14
+- catch encoding errors when reading `Turbomole._run_opt` output files
 
 ## [0.5.0] - 2024-12-16
 ### Changed

--- a/src/mindlessgen/qm/tm.py
+++ b/src/mindlessgen/qm/tm.py
@@ -211,7 +211,7 @@ class Turbomole(QMMethod):
             return tm_log_out, tm_log_err, 0
         except sp.CalledProcessError as e:
             if output_file.exists():
-                with open(output_file, encoding="utf-8") as file:
+                with open(output_file, 'r', encoding="utf-8", errors='replace') as file:
                     tm_log_out = file.read()
             else:
                 tm_log_out = e.stdout.decode(

--- a/src/mindlessgen/qm/tm.py
+++ b/src/mindlessgen/qm/tm.py
@@ -211,7 +211,7 @@ class Turbomole(QMMethod):
             return tm_log_out, tm_log_err, 0
         except sp.CalledProcessError as e:
             if output_file.exists():
-                with open(output_file, 'r', encoding="utf-8", errors='replace') as file:
+                with open(output_file, encoding="utf-8", errors="replace") as file:
                     tm_log_out = file.read()
             else:
                 tm_log_out = e.stdout.decode(


### PR DESCRIPTION
- without replacing errors when reading a file in a specific encoding, encoding errors break the whole calculation (happened to me several times)