### PR TITLE
Fix inconsistencies in `ORCA` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dict keys for elemental compositions will now always be checked for validity
 - Renamed GP3-xTB to g-xTB
 - Moved constants and (empirical) parameters to the `data` module
+- Default for optimization cycles in the postprocessing step set to program default (convergence)
 
 ### Deprecated
 - Nothing will be printed while multiple molecules are generated in parallel, tqdm-based progress bar instead
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - support for TURBOMOLE as QM engine
 - updated the parallelization to work over the number of molecules
 - possibility to generate symmetrical molecules (choice from rotation, inversion, mirroring)
+- Number of optimization steps in the postprocessing part can be set to program default by `none`
 
 ### Fixed
 - version string is now correctly formatted and printed

--- a/mindlessgen.toml
+++ b/mindlessgen.toml
@@ -69,8 +69,8 @@ ncores = 2
 engine = "orca"
 # > Optimize geometry in the post-processing part. If `false`, only a single-point is conducted. Options: <bool>
 optimize = true
-# > Optimization cycles for the post-processing part. If not given, the program default is chosen. Options: <int>
-opt_cycles = 5
+# > Optimization cycles for the post-processing part. If not given or set to "none" or 0, the program default is chosen. Options: <int> or "none"
+opt_cycles = "none"
 # > Debug this step. Leads to more verbose output as soon as the post-processing part is reached. Options: <bool>
 # > If `debug` is true, the process is terminated after the first (successful or not) post-processing step.
 # > Note: This option is only relevant if the 'postprocess' option in the 'general' section is set to 'true'.

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -741,7 +741,7 @@ class PostProcessConfig(BaseConfig):
 
     def __init__(self: PostProcessConfig) -> None:
         self._engine: str = "orca"
-        self._opt_cycles: int | None = 5
+        self._opt_cycles: int | None = None
         self._optimize: bool = True
         self._debug: bool = False
         self._ncores: int = 4

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -795,10 +795,18 @@ class PostProcessConfig(BaseConfig):
         """
         Set the optimization cycles for post-processing.
         """
-        if not isinstance(opt_cycles, int):
-            raise TypeError("Optimization cycles should be an integer.")
+        if not isinstance(opt_cycles, (int, str)):
+            raise TypeError("Optimization cycles can only be an integer or a string.")
+        if isinstance(opt_cycles, str):
+            if opt_cycles.lower() != "none":
+                raise ValueError(
+                    "Optimization cycles can only be an integer or 'none'."
+                )
+            self._opt_cycles = None
+        if opt_cycles == 0:
+            self._opt_cycles = None
         if opt_cycles < 0:
-            raise ValueError("Optimization cycles should be 0 or greater.")
+            raise ValueError("Optimization cycles can only be 0 or greater.")
         self._opt_cycles = opt_cycles
 
     @property

--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -803,8 +803,10 @@ class PostProcessConfig(BaseConfig):
                     "Optimization cycles can only be an integer or 'none'."
                 )
             self._opt_cycles = None
+            return
         if opt_cycles == 0:
             self._opt_cycles = None
+            return
         if opt_cycles < 0:
             raise ValueError("Optimization cycles can only be 0 or greater.")
         self._opt_cycles = opt_cycles

--- a/src/mindlessgen/qm/orca.py
+++ b/src/mindlessgen/qm/orca.py
@@ -171,7 +171,7 @@ class ORCA(QMMethod):
         """
         orca_input = f"! {self.cfg.functional} {self.cfg.basis}\n"
         orca_input += f"! DEFGRID{self.cfg.gridsize}\n"
-        orca_input += "! NoTRAH NoSOSCF SlowConv\n"
+        orca_input += "! NoTRAH\n"
         # "! AutoAux" keyword for super-heavy elements as def2/J ends at Rn
         if any(atom >= 86 for atom in molecule.ati):
             orca_input += "! AutoAux\n"
@@ -179,9 +179,10 @@ class ORCA(QMMethod):
             orca_input += "! OPT\n"
             if opt_cycles is not None:
                 orca_input += f"%geom MaxIter {opt_cycles} end\n"
-        orca_input += (
-            f"%scf\n\tMaxIter {self.cfg.scf_cycles}\n\tConvergence Medium\nend\n"
-        )
+        orca_input += f"%scf\n\tMaxIter {self.cfg.scf_cycles}\n"
+        if not optimization:
+            orca_input += "\tConvergence Medium\n"
+        orca_input += "end\n"
         orca_input += f"%pal nprocs {ncores} end\n\n"
         orca_input += f"* xyzfile {molecule.charge} {molecule.uhf + 1} {xyzfile}\n"
         return orca_input

--- a/src/mindlessgen/qm/orca.py
+++ b/src/mindlessgen/qm/orca.py
@@ -171,6 +171,7 @@ class ORCA(QMMethod):
         """
         orca_input = f"! {self.cfg.functional} {self.cfg.basis}\n"
         orca_input += f"! DEFGRID{self.cfg.gridsize}\n"
+        orca_input += "! MiniPrint\n"
         orca_input += "! NoTRAH\n"
         # "! AutoAux" keyword for super-heavy elements as def2/J ends at Rn
         if any(atom >= 86 for atom in molecule.ati):


### PR DESCRIPTION
- `opt_cycles` can currently not be left out as it's always initialized with an integer and declaring `None` is not a viable option. **Fixed.**
- `NoSOSCF` doesn't make sense in ORCA6.0.1, we should take the default instead.
- `SlowConv` should only be added in specific cases (see issue https://github.com/grimme-lab/MindlessGen/issues/124)
- SCF convergence should not be set to `medium` for geometry optimizations.