### PR TITLE
Update `dev/gp3 ipea`

### DIFF
--- a/src/mindlessgen/prog/config.py
+++ b/src/mindlessgen/prog/config.py
@@ -1650,17 +1650,10 @@ class ConfigManager:
         if not constraints:
             return
 
-        if not self.generate.fixed_composition:
-            raise ValueError(
-                "Distance constraints require 'generate.fixed_composition = true' "
-                + "so individual atoms can be uniquely addressed."
-            )
-
         element_composition = self.generate.element_composition
-        if not element_composition:
-            raise ValueError(
-                "Distance constraints require explicit element composition entries."
-            )
+        # When composition is not fixed, defer feasibility checks until runtime.
+        if not self.generate.fixed_composition or not element_composition:
+            return
 
         for constraint in constraints:
             counts = constraint.required_counts()
@@ -1682,8 +1675,8 @@ class ConfigManager:
                     )
 
                 actual = min_count
-                if actual != expected:
+                if actual < expected:
                     raise ValueError(
-                        f"Distance constraint {constraint} requires exactly "
+                        f"Distance constraint {constraint} requires at least "
                         + f"{expected} {element_symbol} atom(s) but the composition fixes {actual}."
                     )

--- a/test/test_prog/test_distance_constraints.py
+++ b/test/test_prog/test_distance_constraints.py
@@ -36,25 +36,25 @@ def test_force_constant_validation():
         cfg.distance_constraint_force_constant = 0
 
 
-def test_check_config_requires_fixed_composition():
+def test_check_config_allows_non_fixed_composition():
     config = ConfigManager()
     config.general.parallel = 1
     config.refine.ncores = 1
     config.xtb.distance_constraints = [DistanceConstraint.from_cli_string("He,He,2.0")]
     config.generate.fixed_composition = False
+    config.generate.element_composition = "He:2-*"
     config.refine.engine = "xtb"
 
-    with pytest.raises(ValueError):
-        config.check_config()
+    config.check_config()
 
 
-def test_check_config_requires_matching_counts():
+def test_check_config_requires_matching_counts_when_fixed():
     config = ConfigManager()
     config.general.parallel = 1
     config.refine.ncores = 1
     config.xtb.distance_constraints = [DistanceConstraint.from_cli_string("He,He,2.0")]
     config.generate.fixed_composition = True
-    config.generate.element_composition = "He:1-3"
+    config.generate.element_composition = "He:1-1"
     config.refine.engine = "xtb"
 
     with pytest.raises(ValueError):

--- a/test/test_qm/test_xtb.py
+++ b/test/test_qm/test_xtb.py
@@ -176,6 +176,25 @@ def test_prepare_distance_constraint_file_missing_atoms(tmp_path):
         xtb._prepare_distance_constraint_file(mol, tmp_path)
 
 
+def test_distance_constraint_applies_only_first_atoms(tmp_path):
+    cfg = XTBConfig()
+    cfg.distance_constraints = [
+        DistanceConstraint.from_mapping({"pair": ["Fe", "Fe"], "distance": 2.5})
+    ]
+    xtb = XTB("/path/to/xtb", cfg)
+    mol = Molecule("Fe3")
+    mol.ati = np.array([25, 25, 25])
+
+    assert xtb._prepare_distance_constraint_file(mol, tmp_path) is True
+
+    contents = (tmp_path / "xtb.inp").read_text(encoding="utf8").splitlines()
+    distance_lines = [line for line in contents if "distance:" in line]
+
+    assert len(distance_lines) == 1
+    assert "1, 2" in distance_lines[0]
+    assert ", 3," not in distance_lines[0]
+
+
 @pytest.mark.optional
 def test_xtb_distance_constraint_enforced(tmp_path):
     """


### PR DESCRIPTION
- remove need for fixed compositions when using `xtb` constraints